### PR TITLE
Custom jinja template for hierarchical indentation of classes on index page

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -66,10 +66,9 @@ jobs:
     # - name: Install library
     #   run: poetry install --no-interaction
 
-    - name: Create local docs
+    - name: Build and deploy documentation
       run: |
         mkdir docs
         touch docs/.nojekyll
-        cp -r src/docs/* docs/
-        poetry run gen-doc -d docs src/kgcl_schema/schema/kgcl.yaml
-        poetry run mkdocs gh-deploy
+        make gendoc
+        make mkd-gh-deploy

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ SRC = src
 DEST = project
 PYMODEL = $(SRC)/$(SCHEMA_NAME)/datamodel
 DOCDIR = docs
+TEMPLATEDIR = doc-templates
 
 # basename of a YAML file in model/
 .PHONY: all clean
@@ -83,7 +84,7 @@ $(DOCDIR):
 
 gendoc: $(DOCDIR)
 	cp $(SRC)/docs/*md $(DOCDIR) ; \
-	$(RUN) gen-doc -d $(DOCDIR) $(SOURCE_SCHEMA_PATH)
+	$(RUN) gen-doc -d $(DOCDIR) --template-directory $(SRC)/$(TEMPLATEDIR) $(SOURCE_SCHEMA_PATH)
 
 testdoc: gendoc serve
 

--- a/src/doc-templates/index.md.jinja2
+++ b/src/doc-templates/index.md.jinja2
@@ -1,0 +1,46 @@
+# {{ schema.name }}
+
+{{ schema.description }}
+
+URI: <a href={{ schema.id }}>{{ schema.id }}</a>
+
+
+## Classes
+
+| Class | Description |
+| --- | --- |
+{% for u, v in gen.class_hierarchy_as_tuples() -%}
+| {{ "&nbsp;"|safe*u*8 }}{{ gen.link(schemaview.get_class(v)) }} | {{ schemaview.get_class(v).description|enshorten }} |
+{% endfor %}
+
+## Slots
+
+| Slot | Description |
+| --- | --- |
+{% for s in gen.all_slot_objects()|sort(attribute=sort_by) -%}
+| {{gen.link(s)}} | {{s.description|enshorten}} |
+{% endfor %}
+
+## Enumerations
+
+| Enumeration | Description |
+| --- | --- |
+{% for e in gen.all_enum_objects()|sort(attribute=sort_by) -%}
+| {{gen.link(e)}} | {{e.description|enshorten}} |
+{% endfor %}
+
+## Types
+
+| Type | Description |
+| --- | --- |
+{% for t in gen.all_type_objects()|sort(attribute=sort_by) -%}
+| {{gen.link(t)}} | {{t.description|enshorten}} |
+{% endfor %}
+
+## Subsets
+
+| Subset | Description |
+| --- | --- |
+{% for ss in schemaview.all_subsets().values()|sort(attribute='name') -%}
+| {{gen.link(ss)}} | {{ss.description|enshorten}} |
+{% endfor %}


### PR DESCRIPTION
Added a custom index.md.jinja2 file that is consumed by gendoc when rendering the documentation.