### PR TITLE
Added `obsolete` command examples.

### DIFF
--- a/src/data/examples/examples.yaml
+++ b/src/data/examples/examples.yaml
@@ -194,3 +194,19 @@ Test_18:
   about_node_representation: curie
   command_with_curie: remove definition for GO:0005634
   command_with_uri: remove definition for http://purl.obolibrary.org/obo/GO_0005634
+Test_19:
+  id: CHANGE:001
+  type: NodeObsoletion
+  about_node: GO:0005634
+  about_node_representation: curie
+  command_with_curie: obsolete GO:0005634
+  command_with_uri: obsolete http://purl.obolibrary.org/obo/GO_0005634
+Test_20:
+  id: CHANGE:001
+  type: NodeObsoletionWithDirectReplacement
+  about_node: GO:0005634
+  about_node_representation: curie
+  has_direct_replacement: GO:9999999
+  command_with_curie: obsolete GO:0005634 with replacement GO:9999999
+  command_with_uri: obsolete http://purl.obolibrary.org/obo/GO_0005634 with replacement
+    http://purl.obolibrary.org/obo/GO_9999999

--- a/tests/cases.py
+++ b/tests/cases.py
@@ -328,4 +328,25 @@ CASES: List[CASE] = [
         ),
         None,
     ),
+    (
+        f"obsolete {NUCLEUS}",
+        f"obsolete {NUCLEUS_URI}",
+        NodeObsoletion(
+            id=UID,
+            about_node=NUCLEUS,
+            about_node_representation="curie",
+        ),
+        None,
+    ),
+    (
+        f"obsolete {NUCLEUS} with replacement {NEW_TERM}",
+        f"obsolete {NUCLEUS_URI} with replacement {NEW_TERM_URI}",
+        NodeObsoletionWithDirectReplacement(
+            id=UID,
+            about_node=NUCLEUS,
+            about_node_representation="curie",
+            has_direct_replacement=NEW_TERM
+        ),
+        None,
+    ),
 ]


### PR DESCRIPTION
Added the following to `cases.py`
```
    (
        f"obsolete {NUCLEUS}",
        f"obsolete {NUCLEUS_URI}",
        NodeObsoletion(
            id=UID,
            about_node=NUCLEUS,
            about_node_representation="curie",
        ),
        None,
    ),
    (
        f"obsolete {NUCLEUS} with replacement {NEW_TERM}",
        f"obsolete {NUCLEUS_URI} with replacement {NEW_TERM_URI}",
        NodeObsoletionWithDirectReplacement(
            id=UID,
            about_node=NUCLEUS,
            about_node_representation="curie",
            has_direct_replacement=NEW_TERM
        ),
        None,
    ),
```