### PR TITLE
`isinstance()` instead of `eval`

### DIFF
--- a/src/data/examples/examples.yaml
+++ b/src/data/examples/examples.yaml
@@ -1,8 +1,8 @@
 Test_0:
   id: CHANGE:001
   type: NodeRename
-  old_value: '''nuclear envelope'''
-  new_value: '''foo bar'''
+  old_value: nuclear envelope
+  new_value: foo bar
   about_node: GO:0005635
   about_node_representation: curie
   command_with_curie: rename GO:0005635 from 'nuclear envelope' to 'foo bar'
@@ -11,8 +11,8 @@ Test_0:
 Test_1:
   id: CHANGE:001
   type: NodeRename
-  old_value: '''nucleus'''
-  new_value: '''bar'''
+  old_value: nucleus
+  new_value: bar
   about_node: GO:0005634
   about_node_representation: curie
   command_with_curie: rename GO:0005634 from 'nucleus' to 'bar'
@@ -61,10 +61,10 @@ Test_6:
 Test_7:
   id: CHANGE:001
   type: SynonymReplacement
-  old_value: '''cell nucleus'''
-  new_value: '''cell NUCLEUS'''
+  old_value: cell nucleus
+  new_value: cell NUCLEUS
   about_node: GO:0005634
-  about_node_representation: curie
+  about_node_representation: label
   command_with_curie: change synonym 'cell nucleus' for GO:0005634 to 'cell NUCLEUS'
   command_with_uri: change synonym 'cell nucleus' for http://purl.obolibrary.org/obo/GO_0005634
     to 'cell NUCLEUS'
@@ -97,7 +97,7 @@ Test_11:
   about_node: GO:9999999
   about_node_representation: curie
   node_id: GO:9999999
-  name: '''foo'''
+  name: foo
   command_with_curie: create node GO:9999999 'foo'
   command_with_uri: TODO
 Test_12:
@@ -199,7 +199,7 @@ Test_18:
 Test_19:
   id: CHANGE:001
   type: NewTextDefinition
-  new_value: '''this is dummy description'''
+  new_value: this is dummy description
   about_node: GO:0005635
   about_node_representation: curie
   command_with_curie: add definition 'this is dummy description' to GO:0005635
@@ -207,7 +207,7 @@ Test_19:
 Test_20:
   id: CHANGE:001
   type: NodeTextDefinitionChange
-  new_value: '''this is dummy description'''
+  new_value: this is dummy description
   about_node: GO:0005635
   about_node_representation: curie
   command_with_curie: change definition of GO:0005635 to 'this is dummy description'

--- a/src/docs/examples.md
+++ b/src/docs/examples.md
@@ -59,7 +59,7 @@ type: SynonymReplacement
 old_value: cell nucleus
 new_value: cell NUCLEUS
 about_node: GO:0005634
-about_node_representation: curie
+about_node_representation: label
 
 ```
 ## Example: Addition of a node to a subset.

--- a/src/kgcl_schema/grammar/parser.py
+++ b/src/kgcl_schema/grammar/parser.py
@@ -650,8 +650,6 @@ def get_next(generator):
 
 def get_entity_representation(entity):
     """Get entity representation."""
-    if not entity:
-        import pdb; pdb.set_trace()
     first_character = entity[0]
     last_character = entity[-1:]
     if first_character == "<" and last_character == ">":

--- a/src/kgcl_schema/grammar/parser.py
+++ b/src/kgcl_schema/grammar/parser.py
@@ -229,9 +229,12 @@ def parse_remove_synonym(tree, id):
 def parse_change_synonym(tree, id):
     """Change the synonym of a class."""
     entity_token = extract(tree, "entity")
-    old_value = extract(tree, "synonym")
-    new_value = extract(tree, "new_synonym")
     entity, representation = get_entity_representation(entity_token)
+    old_token = extract(tree, "synonym")
+    old_value, representation = get_entity_representation(old_token)
+    new_token = extract(tree, "new_synonym")
+    new_value, representation = get_entity_representation(new_token)
+    
     return SynonymReplacement(
         id=id,
         about_node=entity,
@@ -254,7 +257,8 @@ def parse_create_class(tree, id):
 def parse_add_definition(tree, id):
     """Add definition to class."""
     entity_token = extract(tree, "entity")
-    new_value = extract(tree, "new_definition")
+    new_token = extract(tree, "new_definition")
+    new_value, representation = get_entity_representation(new_token)
     entity, representation = get_entity_representation(entity_token)
     return NewTextDefinition(
         id=id,
@@ -267,8 +271,14 @@ def parse_add_definition(tree, id):
 def parse_change_definition(tree, id):
     """Change the definition of a class."""
     entity_token = extract(tree, "entity")
-    old_value = extract(tree, "old_definition")
-    new_value = extract(tree, "new_definition")
+    old_token = extract(tree, "old_definition")
+    if old_token:
+        old_value, representation = get_entity_representation(old_token)
+    else:
+        old_value = None
+        representation = None
+    new_token = extract(tree, "new_definition")
+    new_value, representation = get_entity_representation(new_token)
     entity, representation = get_entity_representation(entity_token)
     return NodeTextDefinitionChange(
         id=id,
@@ -298,6 +308,7 @@ def parse_create(tree, id):
     """Create a node."""
     term_id_token = extract(tree, "id")
     label_token = extract(tree, "label")
+    label_value, representation = get_entity_representation(label_token)
     language_token = extract(tree, "language")
 
     entity, representation = get_entity_representation(term_id_token)
@@ -307,7 +318,7 @@ def parse_create(tree, id):
         about_node=entity,
         about_node_representation=representation,
         node_id=entity,  # was term_id_token
-        name=label_token,
+        name=label_value,
         language=language_token,
     )
 
@@ -588,7 +599,9 @@ def parse_obsolete(tree, id):
 def parse_rename(tree, id):
     """Rename a node."""
     old_token = extract(tree, "old_label")
+    old_value, representation = get_entity_representation(old_token)
     new_token = extract(tree, "new_label")
+    new_value, representation = get_entity_representation(new_token)
     old_language = extract(tree, "old_language")
     new_language = extract(tree, "new_language")
 
@@ -600,13 +613,12 @@ def parse_rename(tree, id):
     else:
         entity = None
         representation = None
-
     return NodeRename(
         id=id,
         about_node=entity,
         about_node_representation=representation,
-        old_value=old_token,
-        new_value=new_token,
+        old_value=old_value,
+        new_value=new_value,
         old_language=old_language,
         new_language=new_language,
     )
@@ -638,6 +650,8 @@ def get_next(generator):
 
 def get_entity_representation(entity):
     """Get entity representation."""
+    if not entity:
+        import pdb; pdb.set_trace()
     first_character = entity[0]
     last_character = entity[-1:]
     if first_character == "<" and last_character == ">":

--- a/src/kgcl_schema/grammar/render_operations.py
+++ b/src/kgcl_schema/grammar/render_operations.py
@@ -45,8 +45,8 @@ def render_entity(entity, rdf_type):
         entity = entity.replace("'", "")
         return entity
     elif rdf_type == "label":
-        if type(eval(entity)) == Token:
-            entity = eval(entity).value
+        if isinstance(entity, Token):
+            entity = entity.value
         # elif "'" in entity:
         #     # TODO: replacing quotes with backticks
         #     # is only a temporary workaround

--- a/tests/cases.py
+++ b/tests/cases.py
@@ -66,8 +66,8 @@ CASES: List[CASE] = [
         f"rename {NUCLEAR_ENVELOPE_URI} from 'nuclear envelope' to 'foo bar'",
         NodeRename(
             id=UID,
-            old_value="'nuclear envelope'",
-            new_value="'foo bar'",
+            old_value="nuclear envelope",
+            new_value="foo bar",
             about_node="GO:0005635",
             about_node_representation="curie",
         ),
@@ -78,8 +78,8 @@ CASES: List[CASE] = [
         f"rename {NUCLEUS_URI} from 'nucleus' to 'bar'",
         NodeRename(
             id=UID,
-            old_value="'nucleus'",
-            new_value="'bar'",
+            old_value="nucleus",
+            new_value="bar",
             about_node=NUCLEUS,
             about_node_representation="curie",
         ),
@@ -90,8 +90,8 @@ CASES: List[CASE] = [
     #    f"""rename {NUCLEUS} from 'nucleus' to 'bobby " tables'""",
     #    f"""rename {NUCLEUS_URI} from 'nucleus' to 'bobby " tables'""",
     #    NodeRename(id=UID,
-    #               old_value="'nucleus'",
-    #               new_value="'bar'",
+    #               old_value="nucleus",
+    #               new_value="bar",
     #               about_node=NUCLEUS,
     #               about_node_representation='curie'),
     #    None
@@ -155,9 +155,9 @@ CASES: List[CASE] = [
         SynonymReplacement(
             id=UID,
             about_node=NUCLEUS,
-            about_node_representation="curie",
-            old_value="'cell nucleus'",
-            new_value="'cell NUCLEUS'",
+            about_node_representation="label",
+            old_value="cell nucleus",
+            new_value="cell NUCLEUS",
         ),
         None,
     ),
@@ -198,7 +198,7 @@ CASES: List[CASE] = [
             id=UID,
             node_id=NEW_TERM,  ## TODO: remove this
             about_node=NEW_TERM,
-            name="'foo'",
+            name="foo",
             about_node_representation="curie",
         ),
         None,
@@ -212,7 +212,7 @@ CASES: List[CASE] = [
     #     NodeCreation(id=UID,
     #                  node_id=NEW_TERM,   ## TODO: remove this
     #                  about_node=NEW_TERM,
-    #                  name="'foo'",
+    #                  name="foo",
     #                  about_node_representation='curie'),
     #     None
     # ),
@@ -338,7 +338,7 @@ CASES: List[CASE] = [
         f"add definition 'this is dummy description' to {NUCLEAR_ENVELOPE_URI}",
         NewTextDefinition(
             id=UID,
-            new_value="'this is dummy description'",
+            new_value="this is dummy description",
             about_node="GO:0005635",
             about_node_representation="curie",
         ),
@@ -349,7 +349,7 @@ CASES: List[CASE] = [
         f"change definition of {NUCLEAR_ENVELOPE_URI} to 'this is dummy description'",
         NodeTextDefinitionChange(
             id=UID,
-            new_value="'this is dummy description'",
+            new_value="this is dummy description",
             about_node="GO:0005635",
             about_node_representation="curie",
         ),


### PR DESCRIPTION
This fixes a few other things that came to light:

- [x] We need to pass the value of the `Token` object and not the entire object. This is done by
    ```
    new_token = extract(tree, "new_label")
    new_value, representation = get_entity_representation(new_token)
    ```
    I was directly passing `new_token` to the (say) `NodeRename` class which messed things up and there were weird strings with the class name `Token` in them.

- [x] This PR automatically fixes the extra quotes in the tokens since `get_entity_representation()` which was not called earlier takes care of it.

This PR overrides #69 rendering it redundant and a hacky solution