### PR TITLE
Remove `node_id` and replace with `about_node` for `ClassCreation` and `NodeCreation`

### DIFF
--- a/src/data/examples/examples.yaml
+++ b/src/data/examples/examples.yaml
@@ -87,8 +87,8 @@ Test_9:
 Test_10:
   id: CHANGE:001
   type: ClassCreation
+  about_node: GO:9999999
   about_node_representation: curie
-  node_id: GO:9999999
   command_with_curie: create GO:9999999
   command_with_uri: create http://purl.obolibrary.org/obo/GO_9999999
 Test_11:
@@ -96,7 +96,6 @@ Test_11:
   type: NodeCreation
   about_node: GO:9999999
   about_node_representation: curie
-  node_id: GO:9999999
   name: foo
   command_with_curie: create node GO:9999999 'foo'
   command_with_uri: TODO

--- a/src/docs/examples.md
+++ b/src/docs/examples.md
@@ -87,8 +87,8 @@ Class: [`ClassCreation`](https://w3id.org/kgcl/ClassCreation) </br></br>Command:
 ```
 id: CHANGE:001
 type: ClassCreation
+about_node: GO:9999999
 about_node_representation: curie
-node_id: GO:9999999
 
 ```
 ## Example: Creation of new node.
@@ -98,7 +98,6 @@ id: CHANGE:001
 type: NodeCreation
 about_node: GO:9999999
 about_node_representation: curie
-node_id: GO:9999999
 name: foo
 
 ```

--- a/src/kgcl_schema/grammar/parser.py
+++ b/src/kgcl_schema/grammar/parser.py
@@ -250,7 +250,7 @@ def parse_create_class(tree, id):
     entity, representation = get_entity_representation(term_id_token)
 
     return ClassCreation(
-        id=id, node_id=entity, about_node_representation=representation
+        id=id, about_node=entity, about_node_representation=representation
     )
 
 
@@ -317,7 +317,6 @@ def parse_create(tree, id):
         id=id,
         about_node=entity,
         about_node_representation=representation,
-        node_id=entity,  # was term_id_token
         name=label_value,
         language=language_token,
     )

--- a/src/kgcl_schema/grammar/render_operations.py
+++ b/src/kgcl_schema/grammar/render_operations.py
@@ -197,7 +197,7 @@ def render(kgcl_instance: Change) -> str:
             return "create " + subject
 
     if type(kgcl_instance) is ClassCreation:
-        subject = render_entity(kgcl_instance.node_id, "uri")
+        subject = render_entity(kgcl_instance.about_node, "uri")
         return "create " + subject
 
     if type(kgcl_instance) is NewSynonym:

--- a/tests/cases.py
+++ b/tests/cases.py
@@ -186,7 +186,7 @@ CASES: List[CASE] = [
     (
         f"create {NEW_TERM}",
         f"create {NEW_TERM_URI}",
-        ClassCreation(id=UID, node_id=NEW_TERM, about_node_representation="curie"),
+        ClassCreation(id=UID, about_node=NEW_TERM, about_node_representation="curie"),
         None,
     ),
     (
@@ -196,7 +196,6 @@ CASES: List[CASE] = [
         TODO_TOKEN,
         NodeCreation(
             id=UID,
-            node_id=NEW_TERM,  ## TODO: remove this
             about_node=NEW_TERM,
             name="foo",
             about_node_representation="curie",


### PR DESCRIPTION
Fixes https://github.com/INCATools/ontology-access-kit/issues/790

Before this fix: `ClassCreation` KGCL output reflects `create None` since the render operation assigns the value to `node_id` but downstream we're assigning the value to `about_node`. `about_node` seems consistent with all other classes. 